### PR TITLE
feat: Render all the contributors dynamically in the team's page

### DIFF
--- a/app/src/Components/Team/TeamCard.jsx
+++ b/app/src/Components/Team/TeamCard.jsx
@@ -12,7 +12,7 @@ import GitHubIcon from '@mui/icons-material/GitHub'
 
 const TeamCard = (props) => {
     return (
-        <Card sx={{ maxWidth: 345, display:'inline-block'}}>
+        <Card sx={{ width: 345, display:'inline-block'}}>
             <CardHeader
                 avatar={
                     <Avatar sx={{ bgcolor: red[500] }} aria-label="recipe" src={props.imageLink} />
@@ -20,17 +20,17 @@ const TeamCard = (props) => {
                 title={props.name}
                 subheader={props.title}
             />
-            <CardContent>
+            {props.description && <CardContent>
                 <Typography variant="body2" color="text.secondary" align='justify'>
                     {props.description}
                 </Typography>
-            </CardContent>
+            </CardContent>}
             <CardActions disableSpacing>
-                <a style={{ color: 'inherit', textDecoration: 'inherit' }} href={props.linkedin}>
+                {props.linkedin && <a style={{ color: 'inherit', textDecoration: 'inherit' }} href={props.linkedin}>
                     <IconButton aria-label="linkedIn">
                         <LinkedInIcon />
                     </IconButton>
-                </a>
+                </a>}
                 <a style={{ color: 'inherit', textDecoration: 'inherit' }} href={props.github}>
                     <IconButton aria-label="share">
                         <GitHubIcon />

--- a/app/src/Pages/Team.jsx
+++ b/app/src/Pages/Team.jsx
@@ -2,8 +2,28 @@ import React from 'react'
 import TeamCard from '../Components/Team/TeamCard'
 import {Container, Grid, Typography} from '@mui/material'
 import {Helmet} from 'react-helmet'
+import axios from 'axios'
 
 const Team = () => {
+    // List of contributors
+    const [contributors, setContributors] = React.useState()
+
+    React.useEffect(() => {
+        var config = {
+            method: "get",
+            url: "https://api.github.com/repos/Portfolio-Shop/portfolioshop/contributors"
+        }
+        axios(config)
+            .then((response) => {
+                const team = response.data
+                team.splice(0,2)
+                // Filtering out bots
+                setContributors(team.filter((contributor) => {
+                    return !contributor['login'].match("bot")
+                }))
+            })
+    },[])
+
     const leads = [{
         imageLink: "https://avatars.githubusercontent.com/u/74463091?v=4",
         name: "Sudip Mondal",
@@ -39,6 +59,9 @@ const Team = () => {
                 >                
                         {leads.map((lead) => {
                             return <Grid key={lead.github} item><TeamCard imageLink={lead.imageLink} name={lead.name} title={lead.title} description={lead.description} linkedin={lead.linkedin} github={lead.github} /></Grid>
+                        })}
+                        {contributors && contributors.map((contributor) => {
+                            return <Grid key={contributor['html_url']} item><TeamCard imageLink={contributor['avatar_url']} name={contributor['login']} title="Contributor" github={contributor['html_url']} /></Grid>
                         })}
                 </Grid>
             </Container>


### PR DESCRIPTION
# Description

Along with the statically rendered maintainers, the code renders all the contributors dynamically on the `team` page. Used https://api.github.com/repos/Portfolio-Shop/portfolioshop/contributors to fetch the array of objects of contributors of the repository.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Fixes #68 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested locally

## Screenshots (if appropriate)
![#68](https://user-images.githubusercontent.com/74665996/183244376-f81de2ec-f6cb-4abd-91a2-2191e48ef6a2.png)


## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] This PR isn't a duplicate of a previous one
