### PR TITLE
feat: Render a loading screen while API is called to fetch user data

### DIFF
--- a/app/src/Pages/Dashboard.jsx
+++ b/app/src/Pages/Dashboard.jsx
@@ -1,7 +1,8 @@
 import React from 'react'
-import { Box, Container, Button } from '@mui/material'
+import { Box, Container, Button, Backdrop, CircularProgress } from '@mui/material'
 import GoogleLogoutComp from '../Components/ThirdPartyButtons/GoogleLogoutComp'
 import { UserContext } from '../Providers/UserStateProvider'
+import { UserDataContext } from '../Providers/UserDataStateProvider'
 import Website from '../Components/Dashboard/Website'
 import UserDisplayItems from '../Components/Dashboard/UserDisplayItems'
 import About from '../Components/Dashboard/About'
@@ -13,6 +14,7 @@ import Savebutton from '../Components/Dashboard/SaveButton'
 import TicketModal from '../Components/Dashboard/TicketModal'
 
 const Dashboard = () => {
+    const { loading } = React.useContext(UserDataContext)
     const { userEmail } = React.useContext(UserContext)
     const [open, setOpen] = React.useState(false);
     const handleOpen = () => setOpen(true)
@@ -34,6 +36,13 @@ const Dashboard = () => {
                     </Button>
                     <TicketModal open={open} onClose={handleClose} />
                     <GoogleLogoutComp />
+                    {/* Loading screen while the user data is being fetched */}
+                    <Backdrop
+                        sx={{ zIndex: (theme) => theme.zIndex.drawer + 1 }}
+                        open={loading}
+                    >
+                        <CircularProgress size={50} />
+                    </Backdrop>
                     <Website />
                     <UserDisplayItems />
                     <About />

--- a/app/src/Providers/UserDataStateProvider.js
+++ b/app/src/Providers/UserDataStateProvider.js
@@ -22,6 +22,8 @@ const UserDataStateProvider = ({ children }) => {
     const [awards, setAwards] = useState([])
     const [publications, setPublications] = useState([])
     const [cocurricular, setCocurricular] = useState([])
+    // Loading state while fetching user data
+    const [loading, setLoading] = useState(false)
 
     const saveUserData = async () => {
         const data = JSON.stringify({
@@ -63,6 +65,7 @@ const UserDataStateProvider = ({ children }) => {
     }
 
     React.useEffect(() => {
+        setLoading(true)
         axios.get(`/api/userDataRead`,{
             headers:{
                 token: userToken
@@ -70,7 +73,7 @@ const UserDataStateProvider = ({ children }) => {
         }).then(res => {
             setUserData(res?.data?.doc?.templateData || {})
         }).catch((err) => {
-        })
+        }).finally(() => setLoading(false))
     }, [userToken])
 
     React.useEffect(() => {
@@ -115,6 +118,7 @@ const UserDataStateProvider = ({ children }) => {
             awards,
             publications,
             cocurricular,
+            loading,
             setWebsite,
             setName,
             setTagline,


### PR DESCRIPTION
# Description

**Added a loading screen** that is rendered while the API is being called to fetch the user data for the dashboard.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Fixes #59 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested locally

## Screenshots (if appropriate)

https://user-images.githubusercontent.com/74665996/183283763-d0120cfe-58dd-4cc6-a8af-ed2b8693d8d5.mp4

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] This PR isn't a duplicate of a previous one
