### PR TITLE
Improved menubar source button

### DIFF
--- a/app/src/Components/MenuAppBar.jsx
+++ b/app/src/Components/MenuAppBar.jsx
@@ -79,9 +79,9 @@ const MenuAppBar = () => {
                                 </MenuItem>
                             ))}
                             <MenuItem onClick={handleCloseNavMenu}>
-                                <Link style={{ color: 'inherit', textDecoration: 'inherit' }} to={"https://github.com/Portfolio-Shop/portfolioshop"}>
+                                <a style={{ color: 'inherit', textDecoration: 'inherit' }} href={"https://github.com/Portfolio-Shop/portfolioshop"} rel="noopener noreferrer" target="_blank">
                                     <Typography textAlign="center">SOURCE</Typography>
-                                </Link>
+                                </a>
                             </MenuItem>
                         </Menu>
                     </Box>
@@ -108,7 +108,7 @@ const MenuAppBar = () => {
                             onClick={handleCloseNavMenu}
                             sx={{ my: 2, color: 'white', display: 'block' }}
                         >
-                            <a style={{ color: 'white', textDecoration: 'inherit' }} href={"https://github.com/Portfolio-Shop/portfolioshop"}>
+                            <a style={{ color: 'white', textDecoration: 'inherit' }} href={"https://github.com/Portfolio-Shop/portfolioshop"} rel="noopener noreferrer" target="_blank">
                                 {"Source Code"}
                             </a>
                         </Button>


### PR DESCRIPTION
# Description

No need for a Link (react-router-dom) tag for the source button, instead added anchor tag and target as blank so as to open it in the new window tab.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
The Github source code page can be opened in a separate window tab for a better user experience.
<!--- If it fixes an open issue, please link to the issue here. -->


## Screenshots (if appropriate)
Before changes:

![portshop](https://user-images.githubusercontent.com/76991036/187133825-808bc34f-584a-48fe-a4b0-5b24a001d309.png)
After changes:

![portshop2](https://user-images.githubusercontent.com/76991036/187134355-cfd6385a-823c-47b6-a506-7d7e4782ae26.png)
## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] This PR isn't a duplicate of a previous one

